### PR TITLE
Bouygues telecom internet box parser

### DIFF
--- a/config/kibana_reports/BboxThompsonTF787.json
+++ b/config/kibana_reports/BboxThompsonTF787.json
@@ -1,0 +1,829 @@
+{
+  "title": "Bbox Thompson TG787",
+  "services": {
+    "query": {
+      "list": {
+        "0": {
+          "query": "name:adsl_atm_bandwidth_up",
+          "alias": "",
+          "color": "#7EB26D",
+          "id": 0,
+          "pin": false,
+          "type": "lucene",
+          "enable": true
+        },
+        "1": {
+          "id": 1,
+          "color": "#EAB839",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_atm_bandwidth_down"
+        },
+        "2": {
+          "id": 2,
+          "color": "#6ED0E0",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_attenuation_up"
+        },
+        "3": {
+          "id": 3,
+          "color": "#EF843C",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_attenuation_down"
+        },
+        "4": {
+          "id": 4,
+          "color": "#E24D42",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_noise_margin_up"
+        },
+        "5": {
+          "id": 5,
+          "color": "#1F78C1",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_noise_margin_down"
+        },
+        "6": {
+          "id": 6,
+          "color": "#BA43A9",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_crc_up"
+        },
+        "7": {
+          "id": 7,
+          "color": "#705DA0",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_crc_down"
+        },
+        "8": {
+          "id": 8,
+          "color": "#508642",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_fec_up"
+        },
+        "9": {
+          "id": 9,
+          "color": "#CCA300",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_fec_down"
+        },
+        "10": {
+          "id": 10,
+          "color": "#447EBC",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_hec_up"
+        },
+        "11": {
+          "id": 11,
+          "color": "#C15C17",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:adsl_hec_down"
+        },
+        "12": {
+          "id": 12,
+          "color": "#890F02",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "name:generic"
+        }
+      },
+      "ids": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ]
+    },
+    "filter": {
+      "list": {
+        "0": {
+          "type": "time",
+          "field": "created_at",
+          "from": "now-6h",
+          "to": "now",
+          "mandate": "must",
+          "active": true,
+          "alias": "",
+          "id": 0
+        }
+      },
+      "ids": [
+        0
+      ]
+    }
+  },
+  "rows": [
+    {
+      "title": "Gauges",
+      "height": "150px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "created_at",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              0,
+              1
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 1,
+          "linewidth": 3,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": true,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "utc",
+          "percentage": false,
+          "zerofill": false,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "title": "Bandwidth"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "created_at",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              2,
+              3
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 1,
+          "linewidth": 3,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": true,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": false,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "title": "Attenuation"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "created_at",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              4,
+              5
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 1,
+          "linewidth": 3,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": true,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": false,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "title": "Noise"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Other Metrics",
+      "height": "150px",
+      "editable": true,
+      "collapse": true,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "created_at",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              8,
+              9
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 1,
+          "linewidth": 3,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": true,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": false,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "title": "FEC"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "created_at",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              10,
+              11
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 1,
+          "linewidth": 3,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": true,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": false,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "title": "HEC"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "created_at",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              6,
+              7
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 1,
+          "linewidth": 3,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": true,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": false,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "title": "CRC"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Infos",
+      "height": "150px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "height": "200px",
+          "chart": "pie",
+          "field": "_type",
+          "span": 2,
+          "type": "terms",
+          "title": "Top 10 terms in field _type",
+          "exclude": [],
+          "missing": false,
+          "other": false,
+          "size": 10,
+          "order": "count",
+          "style": {
+            "font-size": "10pt"
+          },
+          "donut": true,
+          "tilt": false,
+          "labels": true,
+          "arrangement": "horizontal",
+          "counter_pos": "above",
+          "spyable": true,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12
+            ]
+          },
+          "tmode": "terms",
+          "tstat": "total",
+          "valuefield": ""
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Raw Data",
+      "height": "150px",
+      "editable": true,
+      "collapse": true,
+      "collapsable": true,
+      "panels": [
+        {
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "table",
+          "loadingEditor": false,
+          "size": 100,
+          "pages": 5,
+          "offset": 0,
+          "sort": [
+            "created_at",
+            "desc"
+          ],
+          "overflow": "min-height",
+          "fields": [
+            "_index",
+            "name"
+          ],
+          "highlight": [],
+          "sortable": true,
+          "header": true,
+          "paging": true,
+          "field_list": true,
+          "all_fields": false,
+          "trimFactor": 300,
+          "localTime": true,
+          "timeField": "created_at",
+          "spyable": true,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13
+            ]
+          },
+          "style": {
+            "font-size": "9pt"
+          },
+          "normTimes": true,
+          "title": "Raw Data"
+        }
+      ],
+      "notice": false
+    }
+  ],
+  "editable": true,
+  "failover": false,
+  "index": {
+    "interval": "none",
+    "pattern": "[logstash-]YYYY.MM.DD",
+    "default": "_all",
+    "warm_fields": true
+  },
+  "style": "dark",
+  "panel_hints": true,
+  "pulldowns": [
+    {
+      "type": "query",
+      "collapse": false,
+      "notice": false,
+      "enable": true,
+      "query": "*",
+      "pinned": true,
+      "history": [
+        "name:generic",
+        "name:adsl_hec_down",
+        "name:adsl_hec_up",
+        "name:adsl_fec_down",
+        "name:adsl_fec_up",
+        "name:adsl_crc_down",
+        "name:adsl_crc_up",
+        "name:adsl_noise_margin_down",
+        "name:adsl_noise_margin_up",
+        "name:adsl_attenuation_down"
+      ],
+      "remember": 10
+    },
+    {
+      "type": "filtering",
+      "collapse": false,
+      "notice": true,
+      "enable": true
+    }
+  ],
+  "nav": [
+    {
+      "type": "timepicker",
+      "collapse": false,
+      "notice": false,
+      "enable": true,
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "timefield": "created_at",
+      "now": true,
+      "filter_id": 0
+    }
+  ],
+  "loader": {
+    "save_gist": false,
+    "save_elasticsearch": true,
+    "save_local": true,
+    "save_default": true,
+    "save_temp": true,
+    "save_temp_ttl_enable": true,
+    "save_temp_ttl": "60d",
+    "load_gist": false,
+    "load_elasticsearch": true,
+    "load_elasticsearch_size": 20,
+    "load_local": false,
+    "hide": false
+  },
+  "refresh": "30s"
+}

--- a/internet_box_logger.gemspec
+++ b/internet_box_logger.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'whenever', '~> 0.9'
   spec.add_dependency 'easy_app_helper', '~> 2.0'
   spec.add_dependency 'elasticsearch', '~> 1.0'
+  spec.add_dependency 'nokogiri'
 
 end

--- a/lib/internet_box_logger/generic_box.rb
+++ b/lib/internet_box_logger/generic_box.rb
@@ -6,9 +6,12 @@ module InternetBoxLogger
 
     def initialize(box_type)
       box_type = box_type.to_s if box_type.is_a? Symbol
-      box_type = self.class.const_get box_type if box_type.is_a? String
+      box_type = box_type.constantize if box_type.is_a? String
       box_parser_module = box_type if InternetBoxLogger::Parsers[].include? box_type
-      self.extend box_parser_module
+      self.extend box_parser_module if box_parser_module
+      raise NameError unless box_parser_module
+    rescue NameError => e
+      EasyAppHelper.logger.error "This box type (#{box_type}) doesn\'t seem to exist for now..\nYou can watch the gem's repo for new boxes or create your own wih a pull request."
     end
 
     def log_box_info

--- a/lib/internet_box_logger/parsers.rb
+++ b/lib/internet_box_logger/parsers.rb
@@ -1,5 +1,6 @@
 require 'internet_box_logger/parsers/utils'
 require 'internet_box_logger/parsers/freebox_v5_parser'
+require 'internet_box_logger/parsers/bbox_tg787_parser'
 
 module InternetBoxLogger
   module Parsers

--- a/lib/internet_box_logger/parsers/bbox_tg787_parser.rb
+++ b/lib/internet_box_logger/parsers/bbox_tg787_parser.rb
@@ -1,0 +1,161 @@
+require 'open-uri'
+require 'nokogiri'
+require 'json'
+
+module InternetBoxLogger
+  module Parsers
+    module BboxTg787Parser
+
+      include InternetBoxLogger::Parsers::Utils
+
+      DEFAULT_BOX_HOST = '192.168.1.254'
+
+      LINE_STATUS_URI = '/novice/line.htm'
+
+      LINE_EXPECTED_DATA = [
+
+      ]
+
+      SERVICES_STATUS_URI = '/novice/index.htm'
+
+      BOX_STATUS_URI = '/novice/gtw.htm'
+
+      BOX_EXPECTED_LINES = [
+        /serialnumber\s=\s.*?"(?<serial_number>[\d]+?)"/i ,
+        /macaddress\s=\s.*?"(?<network_mac>[\dabcdefABCDEF:]+?)"/i ,
+        /firmwareversion\s=\s.*?"(?<firmware_version>[\w\d\.-]+?)"/i ,
+        /uptimes\s=\s.*?"(?<firmware_installation_date>[\w\d\-:]+?)"/i
+      ]
+
+      UP_DOWN_LINE_REPORTS = {
+          adsl_noise_margin: 'NoiseMargin',
+          adsl_attenuation: 'Attenuation'
+      }
+
+      UP_DOWN_BITRATES_REPORTS = {
+          adsl_atm_bandwidth: 'InterleavedChannel'
+      }
+
+      attr_accessor :raw_data, :attributes
+
+
+      def get_box_host
+        EasyAppHelper.config[:bbox_alternate_host] ? EasyAppHelper.config[:bbox_alternate_host] : DEFAULT_BOX_HOST
+      end
+
+      def get_box_status_data
+        doc = Nokogiri::HTML open("http://#{get_box_host}#{BOX_STATUS_URI}")
+        StringIO.new doc.css('script')[-3].to_s
+      end
+
+      def get_line_status_data
+        doc = Nokogiri::HTML open("http://#{get_box_host}#{LINE_STATUS_URI}")
+        doc.css('script')[-3].to_s.match(/wandslstatus = eval\(.*?({[^\)]*})/m) do |m|
+          JSON.parse m.captures.first
+        end
+      end
+
+      def map_line_status_data
+        data = get_line_status_data
+        processed = {
+            'adsl_status' => data['State']
+        }
+        %w(up down).each do |direction|
+          UP_DOWN_LINE_REPORTS.each do |stat, key|
+            processed["#{stat}_#{direction}"] = data["#{direction.camelcase}LinePerfs"][key]
+          end
+          UP_DOWN_BITRATES_REPORTS.each do |stat, key|
+            processed["#{stat}_#{direction}"] = data["#{direction.camelcase}Bitrates"][key]
+          end
+        end
+        processed.each do |k, v|
+          EasyAppHelper.logger.info "#{k} => #{v}"
+          @attributes[k.to_sym] = v
+        end
+      end
+
+      def get_services_status_data
+        doc = Nokogiri::HTML open("http://#{get_box_host}#{SERVICES_STATUS_URI}")
+        StringIO.new doc.css('script')[-3].to_s
+      end
+
+      def up_down_reports
+        UP_DOWN_BITRATES_REPORTS.merge UP_DOWN_LINE_REPORTS
+      end
+
+      def get_box_data
+        @raw_data, @attributes = [], {}
+
+        %w(box).each do |data|
+          current_regexp = nil
+          skip_parsing = false
+          regexp_list = InternetBoxLogger::Parsers::BboxTg787Parser.const_get("#{data.upcase}_EXPECTED_LINES").dup
+          send("get_#{data}_status_data".to_sym).readlines.each do |line|
+            @raw_data << line
+            next if skip_parsing
+            begin
+              current_regexp = regexp_list.shift if current_regexp.nil?
+            rescue
+              EasyAppHelper.logger.info 'Got all data. Do not parse the rest of the data.'
+              skip_parsing = true
+            end
+            break if current_regexp.nil?
+            line.encode('utf-8').match current_regexp do |md|
+              md.names.each do |field|
+                EasyAppHelper.logger.info "#{field} => #{md[field]}"
+                @attributes[field.to_sym] = md[field.to_sym]
+                current_regexp = nil
+              end
+            end
+          end
+          # Check if the parsing has been complete
+          regexp_list.empty? ? self : nil
+        end
+
+        map_line_status_data
+      rescue NameError => e
+        EasyAppHelper.logger.debug e
+      end
+
+      def as_es_documents(created_at=Time.now)
+        res = []
+        self.up_down_reports.each_pair do |measurement, name|
+          %w(up down).each do |measurement_type|
+            data_name = "#{measurement}_#{measurement_type}"
+            es_object = {
+                index: "#{self.class.name.underscore.tr('/', '_')}_#{measurement}",
+                type: measurement_type
+            }
+            data = {
+                created_at: created_at,
+                name: data_name,
+                description: name,
+                value: attributes[data_name.to_sym].to_i
+            }
+            es_object[:body] = data
+            res << es_object
+          end
+        end
+        generic_info = {}
+
+        attributes.each do |attr_name, content|
+          # Tries to remove data that are up/down measurements already covered by previous collection
+          data_key = attr_name.to_s.gsub(/_(up|down)$/, '').to_sym
+          next if attr_name.length > 3 && self.up_down_reports.keys.include?(data_key)
+          # Else adds info to generic info
+          generic_info[attr_name] = content
+        end
+        generic_info[:name] = 'generic'
+        generic_info[:created_at] = created_at
+
+        res << {
+            index: "#{self.class.name.underscore.tr('/', '_')}_generic",
+            type: :info.to_s,
+            body: generic_info
+        }
+
+        res
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a parser for the Thompson TG787 Bbox from bouygues telecom's french internet provider.

**Data retrieved:**
- adsl_noise_margin_up
- adsl_noise_margin_down
- adsl_atm_bandwidth_up
- adsl_atm_bandwidth_down
- adsl_attenuation_up
- adsl_attenuation_down
- generic infos:
  - adsl_status
  - firmware_installation_date
  - firmware_version
  - network_mac
  - serial_number
